### PR TITLE
update node sdk with streaming/non-streaming return type fix

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -33,17 +33,16 @@ import {
   ListEvalTasksResponse,
 } from './resources/eval-tasks';
 import {
+  ChatCompletionResponseStreamChunk,
   CompletionResponse,
   EmbeddingsResponse,
   Inference,
   InferenceChatCompletionParams,
   InferenceChatCompletionParamsNonStreaming,
   InferenceChatCompletionParamsStreaming,
-  InferenceChatCompletionResponse,
   InferenceCompletionParams,
   InferenceCompletionParamsNonStreaming,
   InferenceCompletionParamsStreaming,
-  InferenceCompletionResponse,
   InferenceEmbeddingsParams,
   TokenLogProbs,
 } from './resources/inference';
@@ -407,11 +406,10 @@ export declare namespace LlamaStackClient {
 
   export {
     Inference as Inference,
+    type ChatCompletionResponseStreamChunk as ChatCompletionResponseStreamChunk,
     type CompletionResponse as CompletionResponse,
     type EmbeddingsResponse as EmbeddingsResponse,
     type TokenLogProbs as TokenLogProbs,
-    type InferenceChatCompletionResponse as InferenceChatCompletionResponse,
-    type InferenceCompletionResponse as InferenceCompletionResponse,
     type InferenceChatCompletionParams as InferenceChatCompletionParams,
     type InferenceChatCompletionParamsNonStreaming as InferenceChatCompletionParamsNonStreaming,
     type InferenceChatCompletionParamsStreaming as InferenceChatCompletionParamsStreaming,
@@ -538,6 +536,7 @@ export declare namespace LlamaStackClient {
 
   export type AgentConfig = API.AgentConfig;
   export type BatchCompletion = API.BatchCompletion;
+  export type ChatCompletionResponse = API.ChatCompletionResponse;
   export type CompletionMessage = API.CompletionMessage;
   export type ContentDelta = API.ContentDelta;
   export type Document = API.Document;

--- a/src/resources/agents/agents.ts
+++ b/src/resources/agents/agents.ts
@@ -15,11 +15,11 @@ import * as StepsAPI from './steps';
 import { StepRetrieveResponse, Steps } from './steps';
 import * as TurnAPI from './turn';
 import {
+  AgentTurnResponseStreamChunk,
   Turn,
   TurnCreateParams,
   TurnCreateParamsNonStreaming,
   TurnCreateParamsStreaming,
-  TurnCreateResponse,
   TurnResource,
   TurnResponseEvent,
   TurnResponseEventPayload,
@@ -145,10 +145,10 @@ export declare namespace Agents {
 
   export {
     TurnResource as TurnResource,
+    type AgentTurnResponseStreamChunk as AgentTurnResponseStreamChunk,
     type Turn as Turn,
     type TurnResponseEvent as TurnResponseEvent,
     type TurnResponseEventPayload as TurnResponseEventPayload,
-    type TurnCreateResponse as TurnCreateResponse,
     type TurnCreateParams as TurnCreateParams,
     type TurnCreateParamsNonStreaming as TurnCreateParamsNonStreaming,
     type TurnCreateParamsStreaming as TurnCreateParamsStreaming,

--- a/src/resources/agents/index.ts
+++ b/src/resources/agents/index.ts
@@ -20,10 +20,10 @@ export {
 export { Steps, type StepRetrieveResponse } from './steps';
 export {
   TurnResource,
+  type AgentTurnResponseStreamChunk,
   type Turn,
   type TurnResponseEvent,
   type TurnResponseEventPayload,
-  type TurnCreateResponse,
   type TurnCreateParams,
   type TurnCreateParamsNonStreaming,
   type TurnCreateParamsStreaming,

--- a/src/resources/agents/turn.ts
+++ b/src/resources/agents/turn.ts
@@ -14,31 +14,30 @@ export class TurnResource extends APIResource {
     sessionId: string,
     body: TurnCreateParamsNonStreaming,
     options?: Core.RequestOptions,
-  ): APIPromise<TurnCreateResponse>;
+  ): APIPromise<Turn>;
   create(
     agentId: string,
     sessionId: string,
     body: TurnCreateParamsStreaming,
     options?: Core.RequestOptions,
-  ): APIPromise<Stream<TurnCreateResponse>>;
+  ): APIPromise<Stream<AgentTurnResponseStreamChunk>>;
   create(
     agentId: string,
     sessionId: string,
     body: TurnCreateParamsBase,
     options?: Core.RequestOptions,
-  ): APIPromise<Stream<TurnCreateResponse> | TurnCreateResponse>;
+  ): APIPromise<Stream<AgentTurnResponseStreamChunk> | Turn>;
   create(
     agentId: string,
     sessionId: string,
     body: TurnCreateParams,
     options?: Core.RequestOptions,
-  ): APIPromise<TurnCreateResponse> | APIPromise<Stream<TurnCreateResponse>> {
+  ): APIPromise<Turn> | APIPromise<Stream<AgentTurnResponseStreamChunk>> {
     return this._client.post(`/v1/agents/${agentId}/session/${sessionId}/turn`, {
       body,
       ...options,
-      headers: { Accept: 'text/event-stream', ...options?.headers },
       stream: body.stream ?? false,
-    }) as APIPromise<TurnCreateResponse> | APIPromise<Stream<TurnCreateResponse>>;
+    }) as APIPromise<Turn> | APIPromise<Stream<AgentTurnResponseStreamChunk>>;
   }
 
   retrieve(
@@ -49,6 +48,10 @@ export class TurnResource extends APIResource {
   ): Core.APIPromise<Turn> {
     return this._client.get(`/v1/agents/${agentId}/session/${sessionId}/turn/${turnId}`, options);
   }
+}
+
+export interface AgentTurnResponseStreamChunk {
+  event: TurnResponseEvent;
 }
 
 export interface Turn {
@@ -88,22 +91,44 @@ export namespace Turn {
 
   export namespace OutputAttachment {
     export interface ImageContentItem {
+      /**
+       * Image as a base64 encoded string or an URL
+       */
       image: ImageContentItem.Image;
 
+      /**
+       * Discriminator type of the content item. Always "image"
+       */
       type: 'image';
     }
 
     export namespace ImageContentItem {
+      /**
+       * Image as a base64 encoded string or an URL
+       */
       export interface Image {
+        /**
+         * base64 encoded image data as string
+         */
         data?: string;
 
+        /**
+         * A URL of the image or data URL in the format of data:image/{type};base64,{data}.
+         * Note that URL could have length limits.
+         */
         url?: Shared.URL;
       }
     }
 
     export interface TextContentItem {
+      /**
+       * Text content
+       */
       text: string;
 
+      /**
+       * Discriminator type of the content item. Always "text"
+       */
       type: 'text';
     }
   }
@@ -168,14 +193,6 @@ export namespace TurnResponseEventPayload {
   }
 }
 
-export type TurnCreateResponse = Turn | TurnCreateResponse.AgentTurnResponseStreamChunk;
-
-export namespace TurnCreateResponse {
-  export interface AgentTurnResponseStreamChunk {
-    event: TurnAPI.TurnResponseEvent;
-  }
-}
-
 export type TurnCreateParams = TurnCreateParamsNonStreaming | TurnCreateParamsStreaming;
 
 export interface TurnCreateParamsBase {
@@ -202,22 +219,44 @@ export namespace TurnCreateParams {
 
   export namespace Document {
     export interface ImageContentItem {
+      /**
+       * Image as a base64 encoded string or an URL
+       */
       image: ImageContentItem.Image;
 
+      /**
+       * Discriminator type of the content item. Always "image"
+       */
       type: 'image';
     }
 
     export namespace ImageContentItem {
+      /**
+       * Image as a base64 encoded string or an URL
+       */
       export interface Image {
+        /**
+         * base64 encoded image data as string
+         */
         data?: string;
 
+        /**
+         * A URL of the image or data URL in the format of data:image/{type};base64,{data}.
+         * Note that URL could have length limits.
+         */
         url?: Shared.URL;
       }
     }
 
     export interface TextContentItem {
+      /**
+       * Text content
+       */
       text: string;
 
+      /**
+       * Discriminator type of the content item. Always "text"
+       */
       type: 'text';
     }
   }
@@ -242,10 +281,10 @@ export interface TurnCreateParamsStreaming extends TurnCreateParamsBase {
 
 export declare namespace TurnResource {
   export {
+    type AgentTurnResponseStreamChunk as AgentTurnResponseStreamChunk,
     type Turn as Turn,
     type TurnResponseEvent as TurnResponseEvent,
     type TurnResponseEventPayload as TurnResponseEventPayload,
-    type TurnCreateResponse as TurnCreateResponse,
     type TurnCreateParams as TurnCreateParams,
     type TurnCreateParamsNonStreaming as TurnCreateParamsNonStreaming,
     type TurnCreateParamsStreaming as TurnCreateParamsStreaming,

--- a/src/resources/batch-inference.ts
+++ b/src/resources/batch-inference.ts
@@ -2,7 +2,6 @@
 
 import { APIResource } from '../resource';
 import * as Core from '../core';
-import * as InferenceAPI from './inference';
 import * as Shared from './shared';
 
 export class BatchInference extends APIResource {
@@ -22,21 +21,7 @@ export class BatchInference extends APIResource {
 }
 
 export interface BatchInferenceChatCompletionResponse {
-  batch: Array<BatchInferenceChatCompletionResponse.Batch>;
-}
-
-export namespace BatchInferenceChatCompletionResponse {
-  export interface Batch {
-    /**
-     * The complete response message
-     */
-    completion_message: Shared.CompletionMessage;
-
-    /**
-     * Optional log probabilities for generated tokens
-     */
-    logprobs?: Array<InferenceAPI.TokenLogProbs>;
-  }
+  batch: Array<Shared.ChatCompletionResponse>;
 }
 
 export interface BatchInferenceChatCompletionParams {

--- a/src/resources/datasets.ts
+++ b/src/resources/datasets.ts
@@ -35,25 +35,7 @@ export class Datasets extends APIResource {
 }
 
 export interface ListDatasetsResponse {
-  data: Array<ListDatasetsResponse.Data>;
-}
-
-export namespace ListDatasetsResponse {
-  export interface Data {
-    dataset_schema: Record<string, Shared.ParamType>;
-
-    identifier: string;
-
-    metadata: Record<string, boolean | number | string | Array<unknown> | unknown | null>;
-
-    provider_id: string;
-
-    provider_resource_id: string;
-
-    type: 'dataset';
-
-    url: Shared.URL;
-  }
+  data: DatasetListResponse;
 }
 
 export interface DatasetRetrieveResponse {

--- a/src/resources/eval-tasks.ts
+++ b/src/resources/eval-tasks.ts
@@ -40,7 +40,7 @@ export interface EvalTask {
 }
 
 export interface ListEvalTasksResponse {
-  data: Array<EvalTask>;
+  data: EvalTaskListResponse;
 }
 
 export type EvalTaskListResponse = Array<EvalTask>;

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -48,11 +48,10 @@ export {
 } from './eval-tasks';
 export {
   Inference,
+  type ChatCompletionResponseStreamChunk,
   type CompletionResponse,
   type EmbeddingsResponse,
   type TokenLogProbs,
-  type InferenceChatCompletionResponse,
-  type InferenceCompletionResponse,
   type InferenceChatCompletionParams,
   type InferenceChatCompletionParamsNonStreaming,
   type InferenceChatCompletionParamsStreaming,

--- a/src/resources/models.ts
+++ b/src/resources/models.ts
@@ -27,7 +27,7 @@ export class Models extends APIResource {
 }
 
 export interface ListModelsResponse {
-  data: Array<Model>;
+  data: ModelListResponse;
 }
 
 export interface Model {

--- a/src/resources/post-training/job.ts
+++ b/src/resources/post-training/job.ts
@@ -4,9 +4,11 @@ import { APIResource } from '../../resource';
 import * as Core from '../../core';
 
 export class Job extends APIResource {
-  list(options?: Core.RequestOptions): Core.APIPromise<JobListResponse> {
+  list(options?: Core.RequestOptions): Core.APIPromise<Array<ListPostTrainingJobsResponse.Data>> {
     return (
-      this._client.get('/v1/post-training/jobs', options) as Core.APIPromise<{ data: JobListResponse }>
+      this._client.get('/v1/post-training/jobs', options) as Core.APIPromise<{
+        data: Array<ListPostTrainingJobsResponse.Data>;
+      }>
     )._thenUnwrap((obj) => obj.data);
   }
 

--- a/src/resources/providers.ts
+++ b/src/resources/providers.ts
@@ -13,7 +13,7 @@ export class Providers extends APIResource {
 }
 
 export interface ListProvidersResponse {
-  data: Array<InspectAPI.ProviderInfo>;
+  data: ProviderListResponse;
 }
 
 export type ProviderListResponse = Array<InspectAPI.ProviderInfo>;

--- a/src/resources/routes.ts
+++ b/src/resources/routes.ts
@@ -13,7 +13,7 @@ export class Routes extends APIResource {
 }
 
 export interface ListRoutesResponse {
-  data: Array<InspectAPI.RouteInfo>;
+  data: RouteListResponse;
 }
 
 export type RouteListResponse = Array<InspectAPI.RouteInfo>;

--- a/src/resources/scoring-functions.ts
+++ b/src/resources/scoring-functions.ts
@@ -27,7 +27,7 @@ export class ScoringFunctions extends APIResource {
 }
 
 export interface ListScoringFunctionsResponse {
-  data: Array<ScoringFn>;
+  data: ScoringFunctionListResponse;
 }
 
 export interface ScoringFn {

--- a/src/resources/shared.ts
+++ b/src/resources/shared.ts
@@ -42,6 +42,18 @@ export interface BatchCompletion {
   batch: Array<InferenceAPI.CompletionResponse>;
 }
 
+export interface ChatCompletionResponse {
+  /**
+   * The complete response message
+   */
+  completion_message: CompletionMessage;
+
+  /**
+   * Optional log probabilities for generated tokens
+   */
+  logprobs?: Array<InferenceAPI.TokenLogProbs>;
+}
+
 export interface CompletionMessage {
   /**
    * The content of the model's response
@@ -110,22 +122,44 @@ export interface Document {
 
 export namespace Document {
   export interface ImageContentItem {
+    /**
+     * Image as a base64 encoded string or an URL
+     */
     image: ImageContentItem.Image;
 
+    /**
+     * Discriminator type of the content item. Always "image"
+     */
     type: 'image';
   }
 
   export namespace ImageContentItem {
+    /**
+     * Image as a base64 encoded string or an URL
+     */
     export interface Image {
+      /**
+       * base64 encoded image data as string
+       */
       data?: string;
 
+      /**
+       * A URL of the image or data URL in the format of data:image/{type};base64,{data}.
+       * Note that URL could have length limits.
+       */
       url?: Shared.URL;
     }
   }
 
   export interface TextContentItem {
+    /**
+     * Text content
+     */
     text: string;
 
+    /**
+     * Discriminator type of the content item. Always "text"
+     */
     type: 'text';
   }
 }
@@ -138,22 +172,44 @@ export type InterleavedContent =
 
 export namespace InterleavedContent {
   export interface ImageContentItem {
+    /**
+     * Image as a base64 encoded string or an URL
+     */
     image: ImageContentItem.Image;
 
+    /**
+     * Discriminator type of the content item. Always "image"
+     */
     type: 'image';
   }
 
   export namespace ImageContentItem {
+    /**
+     * Image as a base64 encoded string or an URL
+     */
     export interface Image {
+      /**
+       * base64 encoded image data as string
+       */
       data?: string;
 
+      /**
+       * A URL of the image or data URL in the format of data:image/{type};base64,{data}.
+       * Note that URL could have length limits.
+       */
       url?: Shared.URL;
     }
   }
 
   export interface TextContentItem {
+    /**
+     * Text content
+     */
     text: string;
 
+    /**
+     * Discriminator type of the content item. Always "text"
+     */
     type: 'text';
   }
 }
@@ -164,22 +220,44 @@ export type InterleavedContentItem =
 
 export namespace InterleavedContentItem {
   export interface ImageContentItem {
+    /**
+     * Image as a base64 encoded string or an URL
+     */
     image: ImageContentItem.Image;
 
+    /**
+     * Discriminator type of the content item. Always "image"
+     */
     type: 'image';
   }
 
   export namespace ImageContentItem {
+    /**
+     * Image as a base64 encoded string or an URL
+     */
     export interface Image {
+      /**
+       * base64 encoded image data as string
+       */
       data?: string;
 
+      /**
+       * A URL of the image or data URL in the format of data:image/{type};base64,{data}.
+       * Note that URL could have length limits.
+       */
       url?: Shared.URL;
     }
   }
 
   export interface TextContentItem {
+    /**
+     * Text content
+     */
     text: string;
 
+    /**
+     * Discriminator type of the content item. Always "text"
+     */
     type: 'text';
   }
 }

--- a/src/resources/shields.ts
+++ b/src/resources/shields.ts
@@ -20,7 +20,7 @@ export class Shields extends APIResource {
 }
 
 export interface ListShieldsResponse {
-  data: Array<Shield>;
+  data: ShieldListResponse;
 }
 
 export interface Shield {

--- a/src/resources/telemetry.ts
+++ b/src/resources/telemetry.ts
@@ -165,25 +165,7 @@ export interface QueryCondition {
 }
 
 export interface QuerySpansResponse {
-  data: Array<QuerySpansResponse.Data>;
-}
-
-export namespace QuerySpansResponse {
-  export interface Data {
-    name: string;
-
-    span_id: string;
-
-    start_time: string;
-
-    trace_id: string;
-
-    attributes?: Record<string, boolean | number | string | Array<unknown> | unknown | null>;
-
-    end_time?: string;
-
-    parent_span_id?: string;
-  }
+  data: TelemetryQuerySpansResponse;
 }
 
 export interface SpanWithStatus {

--- a/src/resources/toolgroups.ts
+++ b/src/resources/toolgroups.ts
@@ -41,7 +41,7 @@ export class Toolgroups extends APIResource {
 }
 
 export interface ListToolGroupsResponse {
-  data: Array<ToolGroup>;
+  data: ToolgroupListResponse;
 }
 
 export interface ToolGroup {

--- a/src/resources/tools.ts
+++ b/src/resources/tools.ts
@@ -28,7 +28,7 @@ export class Tools extends APIResource {
 }
 
 export interface ListToolsResponse {
-  data: Array<Tool>;
+  data: ToolListResponse;
 }
 
 export interface Tool {

--- a/src/resources/vector-dbs.ts
+++ b/src/resources/vector-dbs.ts
@@ -33,23 +33,7 @@ export class VectorDBs extends APIResource {
 }
 
 export interface ListVectorDBsResponse {
-  data: Array<ListVectorDBsResponse.Data>;
-}
-
-export namespace ListVectorDBsResponse {
-  export interface Data {
-    embedding_dimension: number;
-
-    embedding_model: string;
-
-    identifier: string;
-
-    provider_id: string;
-
-    provider_resource_id: string;
-
-    type: 'vector_db';
-  }
+  data: VectorDBListResponse;
 }
 
 export interface VectorDBRetrieveResponse {

--- a/tests/api-resources/agents/turn.test.ts
+++ b/tests/api-resources/agents/turn.test.ts
@@ -6,8 +6,7 @@ import { Response } from 'node-fetch';
 const client = new LlamaStackClient({ baseURL: process.env['TEST_API_BASE_URL'] ?? 'http://127.0.0.1:4010' });
 
 describe('resource turn', () => {
-  // skipped: currently no good way to test endpoints with content type text/event-stream, Prism mock server will fail
-  test.skip('create: only required params', async () => {
+  test('create: only required params', async () => {
     const responsePromise = client.agents.turn.create('agent_id', 'session_id', {
       messages: [{ content: 'string', role: 'user' }],
     });
@@ -20,8 +19,7 @@ describe('resource turn', () => {
     expect(dataAndResponse.response).toBe(rawResponse);
   });
 
-  // skipped: currently no good way to test endpoints with content type text/event-stream, Prism mock server will fail
-  test.skip('create: required and optional params', async () => {
+  test('create: required and optional params', async () => {
     const response = await client.agents.turn.create('agent_id', 'session_id', {
       messages: [{ content: 'string', role: 'user', context: 'string' }],
       documents: [{ content: 'string', mime_type: 'mime_type' }],

--- a/tests/api-resources/inference.test.ts
+++ b/tests/api-resources/inference.test.ts
@@ -6,8 +6,7 @@ import { Response } from 'node-fetch';
 const client = new LlamaStackClient({ baseURL: process.env['TEST_API_BASE_URL'] ?? 'http://127.0.0.1:4010' });
 
 describe('resource inference', () => {
-  // skipped: currently no good way to test endpoints with content type text/event-stream, Prism mock server will fail
-  test.skip('chatCompletion: only required params', async () => {
+  test('chatCompletion: only required params', async () => {
     const responsePromise = client.inference.chatCompletion({
       messages: [{ content: 'string', role: 'user' }],
       model_id: 'model_id',
@@ -21,8 +20,7 @@ describe('resource inference', () => {
     expect(dataAndResponse.response).toBe(rawResponse);
   });
 
-  // skipped: currently no good way to test endpoints with content type text/event-stream, Prism mock server will fail
-  test.skip('chatCompletion: required and optional params', async () => {
+  test('chatCompletion: required and optional params', async () => {
     const response = await client.inference.chatCompletion({
       messages: [{ content: 'string', role: 'user', context: 'string' }],
       model_id: 'model_id',
@@ -44,8 +42,7 @@ describe('resource inference', () => {
     });
   });
 
-  // skipped: currently no good way to test endpoints with content type text/event-stream, Prism mock server will fail
-  test.skip('completion: only required params', async () => {
+  test('completion: only required params', async () => {
     const responsePromise = client.inference.completion({ content: 'string', model_id: 'model_id' });
     const rawResponse = await responsePromise.asResponse();
     expect(rawResponse).toBeInstanceOf(Response);
@@ -56,8 +53,7 @@ describe('resource inference', () => {
     expect(dataAndResponse.response).toBe(rawResponse);
   });
 
-  // skipped: currently no good way to test endpoints with content type text/event-stream, Prism mock server will fail
-  test.skip('completion: required and optional params', async () => {
+  test('completion: required and optional params', async () => {
     const response = await client.inference.completion({
       content: 'string',
       model_id: 'model_id',


### PR DESCRIPTION
# What
- sync with https://github.com/meta-llama/llama-stack/pull/910
- update examples to use ESM

# Test

```
npm test examples
```

```
./examples/inference.ts
```